### PR TITLE
refactor(containers): rename connectStore -> pluggedIn

### DIFF
--- a/docs/architecture/convention.md
+++ b/docs/architecture/convention.md
@@ -50,7 +50,7 @@ we can easily import files like:
 
 ```js
 import { ISSUE_WEB } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleEditFooter from '@/components/ArticleEditFooter'
 ...
@@ -68,7 +68,7 @@ Import Waypoint from 'react-waypoint'
 Import R from 'ramda'
 
 // 2. import utils
-Import { connectStore, buildLog, ROUTE, THREAD } from '@/utils'
+Import { pluggedIn, buildLog, ROUTE, THREAD } from '@/utils'
 
 // 3. import global containers
 Import TagsBar from '@/containers/unit/TagsBar'

--- a/docs/architecture/convention.zh-CN.md
+++ b/docs/architecture/convention.zh-CN.md
@@ -50,7 +50,7 @@ Doramon 为网站提供类似于 [alfred](https://www.alfredapp.com/) 的功能,
 
 ```js
 import { ISSUE_WEB } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleEditFooter from '@/components/ArticleEditFooter'
 ...
@@ -67,7 +67,7 @@ import { inject, observer } from 'mobx-react'
 import Waypoint from 'react-waypoint'
 
 // 2. import utils
-import { connectStore, buildLog, ROUTE, THREAD } from '@/utils'
+import { pluggedIn, buildLog, ROUTE, THREAD } from '@/utils'
 
 // 3. import global containers
 import TagsBar from '@/containers/unit/TagsBar'

--- a/docs/architecture/intro.md
+++ b/docs/architecture/intro.md
@@ -154,7 +154,7 @@ import Editor from './Editor'
 
 import { Wrapper, ViewerWrapper } from './styles'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import { useInit, changeView, onPublish, cancelPublish } from './logic'
 
 const PostEditorContainer = ({ postEditor: store, attachment }) =>{
@@ -181,13 +181,13 @@ const PostEditorContainer = ({ postEditor: store, attachment }) =>{
   )
 }
 
-export default connectStore(PostEditorContainer)
+export default pluggedIn(PostEditorContainer)
 ```
 
 Based on my own experience and the actual situation of the project's evolution over the past year, I think the local state is bad. So all the states are handed to the external state management tool [Mobx-State-Tree](https://github.com/mobxjs/mobx-state-tree), and then the container is linked to the entire project state tree by the following function. Corresponding substate trees are linked together
 
 ```js
-export default connectStore(PostEditorContainer)
+export default pluggedIn(PostEditorContainer)
 ```
 
 #### store.js

--- a/docs/architecture/intro.zh-CN.md
+++ b/docs/architecture/intro.zh-CN.md
@@ -151,7 +151,7 @@ import Editor from './Editor'
 
 import { Wrapper, ViewerWrapper } from './styles'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import { useInit, changeView, onPublish, cancelPublish } from './logic'
 
 const PostEditorContainer = ({ postEditor: store, attachment }) =>{
@@ -178,13 +178,13 @@ const PostEditorContainer = ({ postEditor: store, attachment }) =>{
   )
 }
 
-export default connectStore(PostEditorContainer)
+export default pluggedIn(PostEditorContainer)
 ```
 
 根据我自己的一些经验和项目一年来演进的实际情况，我认为局部状态是糟糕的。所以所有的状态都交于外部的状态管理工具 [Mobx-State-Tree](https://github.com/mobxjs/mobx-state-tree), 然后通过下面函数将该容器与整个项目状态树中相对应的子状态树链接起来：
 
 ```js
-export default connectStore(PostEditorContainer)
+export default pluggedIn(PostEditorContainer)
 ```
 
 #### store.js

--- a/docs/js/state-management.md
+++ b/docs/js/state-management.md
@@ -8,10 +8,10 @@ The root state tree is a combination of the child-state-tree (store.js) scattere
 
 #### child state tree
 
-The substate tree exists only in the container component, named store.js, and is connected to the root state tree via [connectStore](https://github.com/coderplanets/coderplanets_web/blob/dev/utils/mobx_helper.js#L37) Take the PostEditor container as an example:
+The substate tree exists only in the container component, named store.js, and is connected to the root state tree via [pluggedIn](https://github.com/coderplanets/coderplanets_web/blob/dev/utils/mobx_helper.js#L37) Take the PostEditor container as an example:
 
 ```js
-export default connectStore(PostEditorContainer)
+export default pluggedIn(PostEditorContainer)
 ```
 
 Containers/PostEditor/store.js in the same directory only contains the state required by the PostEditor container, and the state can only be changed by the method method exposed in the store, which is changed by the method call in logic.js in the same directory. The view layer cannot be directly Change the status.

--- a/docs/js/state-management.zh-CN.md
+++ b/docs/js/state-management.zh-CN.md
@@ -8,10 +8,10 @@ root 状态树由分散在各个容器组件内的子状态树(store.js) 以及 
 
 #### 子状态树
 
-子状态树只存在于容器组件, 统一命名为 store.js, 通过 [connectStore](https://github.com/coderplanets/coderplanets_web/blob/dev/utils/mobx_helper.js#L37) 连接到根状态树, 以 PostEditor 容器为例:
+子状态树只存在于容器组件, 统一命名为 store.js, 通过 [pluggedIn](https://github.com/coderplanets/coderplanets_web/blob/dev/utils/mobx_helper.js#L37) 连接到根状态树, 以 PostEditor 容器为例:
 
 ```js
-export default connectStore(PostEditorContainer)
+export default pluggedIn(PostEditorContainer)
 ```
 
 相同目录下的 containers/PostEditor/store.js 只包含 PostEditor 容器所需的状态，且状态只能通过该 store 暴露出的 action 方法，由同目录下 logic.js 中的方法调用改变， 视图层无法直接改变状态。

--- a/src/containers/Route/index.js
+++ b/src/containers/Route/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import { useRouter } from 'next/router'
 
-import { connectStore } from '@/utils'
+import { pluggedIn } from '@/utils'
 import { useInit } from './logic'
 
 const RouteContainer = ({ route }) => {
@@ -17,4 +17,4 @@ const RouteContainer = ({ route }) => {
   return <div />
 }
 
-export default connectStore(RouteContainer)
+export default pluggedIn(RouteContainer)

--- a/src/containers/content/CommunityContent/index.js
+++ b/src/containers/content/CommunityContent/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 
 import { ROUTE, C11N } from '@/constant'
 import { useDevice } from '@/hooks'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import PostsThread from '@/containers//thread/PostsThread'
 import VideosThread from '@/containers/thread/VideosThread'
@@ -72,4 +72,4 @@ const CommunityContentContainer = ({ communityContent: store }) => {
   )
 }
 
-export default connectStore(CommunityContentContainer)
+export default pluggedIn(CommunityContentContainer)

--- a/src/containers/content/CoolGuideContent/index.js
+++ b/src/containers/content/CoolGuideContent/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import FilterBar from './FilterBar'
 import Content from './Content'
@@ -38,4 +38,4 @@ const CoolGuideContentContainer = ({ coolGuideContent: store, metric }) => {
   )
 }
 
-export default connectStore(CoolGuideContentContainer)
+export default pluggedIn(CoolGuideContentContainer)

--- a/src/containers/content/DiscoveryContent/index.js
+++ b/src/containers/content/DiscoveryContent/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import { isEmpty } from 'ramda'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Pagi from '@/components/Pagi'
 
@@ -77,4 +77,4 @@ const DiscoveryContentContainer = ({ discoveryContent: store, metric }) => {
   )
 }
 
-export default connectStore(DiscoveryContentContainer)
+export default pluggedIn(DiscoveryContentContainer)

--- a/src/containers/content/FriendsContent/index.js
+++ b/src/containers/content/FriendsContent/index.js
@@ -8,7 +8,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { Br } from '@/components/Common'
 import { FriendsGallery } from '@/components/GalleryHub'
@@ -117,4 +117,4 @@ const FriendsContentContainer = ({ friendsContent: store, metric }) => {
   )
 }
 
-export default connectStore(FriendsContentContainer)
+export default pluggedIn(FriendsContentContainer)

--- a/src/containers/content/HaveADrinkContent/index.js
+++ b/src/containers/content/HaveADrinkContent/index.js
@@ -7,13 +7,7 @@
 import React from 'react'
 import dynamic from 'next/dynamic'
 
-import {
-  connectStore,
-  buildLog,
-  scrollToTop,
-  lockPage,
-  unlockPage,
-} from '@/utils'
+import { pluggedIn, buildLog, scrollToTop, lockPage, unlockPage } from '@/utils'
 import { useShortcut } from '@/hooks'
 
 import Header from './Header'
@@ -68,4 +62,4 @@ const HaveADrinkContentContainer = ({ haveADrinkContent: store }) => {
   )
 }
 
-export default connectStore(HaveADrinkContentContainer)
+export default pluggedIn(HaveADrinkContentContainer)

--- a/src/containers/content/JobContent/index.js
+++ b/src/containers/content/JobContent/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleBodyHeader from '@/containers/unit/ArticleBodyHeader'
 import Comments from '@/containers/unit/Comments'
@@ -84,4 +84,4 @@ const JobContentContainer = ({ jobContent: store }) => {
   )
 }
 
-export default connectStore(JobContentContainer)
+export default pluggedIn(JobContentContainer)

--- a/src/containers/content/MeetupsContent/index.js
+++ b/src/containers/content/MeetupsContent/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 
 import { ASSETS_ENDPOINT } from '@/config'
 import { GALLERY } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Pagi from '@/components/Pagi'
 import { PagiOptionSwitcher } from '@/components/Switcher'
@@ -72,4 +72,4 @@ const MeetupsContentContainer = ({ meetupsContent: store }) => {
   )
 }
 
-export default connectStore(MeetupsContentContainer)
+export default pluggedIn(MeetupsContentContainer)

--- a/src/containers/content/MembershipContent/index.js
+++ b/src/containers/content/MembershipContent/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 import T from 'prop-types'
 
 // import { ICON_CMD, EMAIL_BUSINESS, SENIOR_AMOUNT_THRESHOLD } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { OrButton, Button } from '@/components/Buttons'
 import Checker from '@/components/Checker'
@@ -154,4 +154,4 @@ MembershipContentContainer.defaultProps = {
   testId: 'membership-content',
 }
 
-export default connectStore(MembershipContentContainer)
+export default pluggedIn(MembershipContentContainer)

--- a/src/containers/content/PostContent/DesktopView.js
+++ b/src/containers/content/PostContent/DesktopView.js
@@ -7,7 +7,7 @@
 import React, { useRef } from 'react'
 import { Waypoint } from 'react-waypoint'
 
-import { connectStore, buildLog, isElementInViewport } from '@/utils'
+import { pluggedIn, buildLog, isElementInViewport } from '@/utils'
 
 import Comments from '@/containers/unit/Comments'
 // import ArticleAuthorCard from '@/containers/unit/ArticleAuthorCard'
@@ -70,4 +70,4 @@ const PostContentContainer = ({ postContent: store, metric }) => {
   )
 }
 
-export default connectStore(PostContentContainer)
+export default pluggedIn(PostContentContainer)

--- a/src/containers/content/PostContent/MobileView.js
+++ b/src/containers/content/PostContent/MobileView.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import { Waypoint } from 'react-waypoint'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Comments from '@/containers/unit/Comments'
 // import ArticleAuthorCard from '@/containers/unit/ArticleAuthorCard'
@@ -53,4 +53,4 @@ const PostContentContainer = ({ postContent: store }) => {
   )
 }
 
-export default connectStore(PostContentContainer)
+export default pluggedIn(PostContentContainer)

--- a/src/containers/content/RecipesContent/index.js
+++ b/src/containers/content/RecipesContent/index.js
@@ -8,7 +8,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import { RECIPE } from '@/constant'
 
 import Snippets from './Snippets'
@@ -47,4 +47,4 @@ const RecipesContentContainer = ({ recipesContent: store, metric }) => {
   )
 }
 
-export default connectStore(RecipesContentContainer)
+export default pluggedIn(RecipesContentContainer)

--- a/src/containers/content/RepoContent/index.js
+++ b/src/containers/content/RepoContent/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Comments from '@/containers/unit/Comments'
 import ArticleAuthorCard from '@/containers/unit/ArticleAuthorCard'
@@ -71,4 +71,4 @@ const RepoContentContainer = ({ repoContent: store }) => {
   )
 }
 
-export default connectStore(RepoContentContainer)
+export default pluggedIn(RepoContentContainer)

--- a/src/containers/content/SponsorContent/index.js
+++ b/src/containers/content/SponsorContent/index.js
@@ -8,7 +8,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { Br } from '@/components/Common'
 import { SponsorGallery } from '@/components/GalleryHub'
@@ -138,4 +138,4 @@ const SponsorContentContainer = ({ sponsorContent: store, metric }) => {
   )
 }
 
-export default connectStore(SponsorContentContainer)
+export default pluggedIn(SponsorContentContainer)

--- a/src/containers/content/SubscribeContent/index.js
+++ b/src/containers/content/SubscribeContent/index.js
@@ -9,7 +9,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Content from './Content'
 import Actions from './Actions'
@@ -46,4 +46,4 @@ SubscribeContentContainer.defaultProps = {
   testId: 'subscribe-content',
 }
 
-export default connectStore(SubscribeContentContainer)
+export default pluggedIn(SubscribeContentContainer)

--- a/src/containers/content/TrendingContent/index.js
+++ b/src/containers/content/TrendingContent/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { OrButton } from '@/components/Buttons'
 import NewsBoard from './NewsBoard'
@@ -48,4 +48,4 @@ const TrendingContentContainer = ({ trendingContent: store, metric }) => {
   )
 }
 
-export default connectStore(TrendingContentContainer)
+export default pluggedIn(TrendingContentContainer)

--- a/src/containers/content/UserContent/index.js
+++ b/src/containers/content/UserContent/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { USER_THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import UserProfile from '@/containers/user/UserProfile'
 import UserPublished from '@/containers/user/UserPublished'
@@ -135,4 +135,4 @@ const UserContentContainer = ({ userContent: store, metric }) => {
   )
 }
 
-export default connectStore(UserContentContainer)
+export default pluggedIn(UserContentContainer)

--- a/src/containers/content/VideoContent/index.js
+++ b/src/containers/content/VideoContent/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleBodyHeader from '@/containers/unit/ArticleBodyHeader'
 import Comments from '@/containers/unit/Comments'
@@ -88,4 +88,4 @@ const VideoContentContainer = ({ videoContent: store }) => {
   )
 }
 
-export default connectStore(VideoContentContainer)
+export default pluggedIn(VideoContentContainer)

--- a/src/containers/content/WorksContent/index.js
+++ b/src/containers/content/WorksContent/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Pagi from '@/components/Pagi'
 import AvatarsRow from '@/components/AvatarsRow'
@@ -93,4 +93,4 @@ const WorksContentContainer = ({ worksContent: store, metric }) => {
   )
 }
 
-export default connectStore(WorksContentContainer)
+export default pluggedIn(WorksContentContainer)

--- a/src/containers/digest/ArticleDigest/DesktopView/index.js
+++ b/src/containers/digest/ArticleDigest/DesktopView/index.js
@@ -11,7 +11,7 @@ import { Waypoint } from 'react-waypoint'
 
 import { METRIC } from '@/constant'
 import { useScroll } from '@/hooks'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import FavoritesCats from '@/containers/tool/FavoritesCats'
 import Author from './Author'
@@ -76,4 +76,4 @@ ArticleDigestContainer.defaultProps = {
   metric: METRIC.ARTICLE,
 }
 
-export default connectStore(ArticleDigestContainer)
+export default pluggedIn(ArticleDigestContainer)

--- a/src/containers/digest/ArticleDigest/MobileView/index.js
+++ b/src/containers/digest/ArticleDigest/MobileView/index.js
@@ -10,7 +10,7 @@ import { isNil } from 'ramda'
 import { Waypoint } from 'react-waypoint'
 
 import { useScroll } from '@/hooks'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import FavoritesCats from '@/containers/tool/FavoritesCats'
 
@@ -60,4 +60,4 @@ ArticleDigestContainer.propTypes = {
 
 ArticleDigestContainer.defaultProps = {}
 
-export default connectStore(ArticleDigestContainer)
+export default pluggedIn(ArticleDigestContainer)

--- a/src/containers/digest/CommunityDigest/index.js
+++ b/src/containers/digest/CommunityDigest/index.js
@@ -6,7 +6,7 @@
 import React from 'react'
 
 import { C11N } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import DigestView from './DigestView/index'
 import BriefView from './BriefView'
@@ -52,4 +52,4 @@ const CommunityDigestContainer = ({ communityDigest: store, metric }) => {
   )
 }
 
-export default connectStore(CommunityDigestContainer)
+export default pluggedIn(CommunityDigestContainer)

--- a/src/containers/editor/AccountEditor/index.js
+++ b/src/containers/editor/AccountEditor/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { ICON_CMD } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { Button } from '@/components/Buttons'
 import StatusBox from '@/components/StatusBox'
@@ -122,4 +122,4 @@ const AccountEditorContainer = ({ accountEditor: store }) => {
   )
 }
 
-export default connectStore(AccountEditorContainer)
+export default pluggedIn(AccountEditorContainer)

--- a/src/containers/editor/ArticleEditor/index.js
+++ b/src/containers/editor/ArticleEditor/index.js
@@ -11,7 +11,7 @@ import T from 'prop-types'
 import { values } from 'ramda'
 
 import { METRIC } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { STEP } from './constant'
 import Editor from './Editor'
@@ -52,4 +52,4 @@ ArticleEditorContainer.defaultProps = {
   metric: METRIC.ARTICLE_EDITOR,
 }
 
-export default connectStore(ArticleEditorContainer)
+export default pluggedIn(ArticleEditorContainer)

--- a/src/containers/editor/CommunityEditor/index.js
+++ b/src/containers/editor/CommunityEditor/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Banner from './Banner'
 import Content from './Content'
@@ -47,4 +47,4 @@ CommunityEditorContainer.getInitialProps = async () => ({
   namespacesRequired: ['common'],
 })
 
-export default connectStore(CommunityEditorContainer)
+export default pluggedIn(CommunityEditorContainer)

--- a/src/containers/editor/JobEditor/index.js
+++ b/src/containers/editor/JobEditor/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import dynamic from 'next/dynamic'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleEditFooter from '@/components/ArticleEditFooter'
 import { ArticleContentLoading } from '@/components/LoadingEffects'
@@ -109,4 +109,4 @@ const JobEditorContainer = ({ jobEditor: store, attachment }) => {
 
 // JobEditorContainer.defaultProps = {}
 
-export default connectStore(JobEditorContainer)
+export default pluggedIn(JobEditorContainer)

--- a/src/containers/editor/PostEditor/index.js
+++ b/src/containers/editor/PostEditor/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 /* import T from 'prop-types' */
 import dynamic from 'next/dynamic'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleEditFooter from '@/components/ArticleEditFooter'
 import { ArticleContentLoading } from '@/components/LoadingEffects'
@@ -125,4 +125,4 @@ const PostEditorContainer = ({ postEditor: store, attachment }) => {
   )
 }
 
-export default connectStore(PostEditorContainer)
+export default pluggedIn(PostEditorContainer)

--- a/src/containers/editor/RepoEditor/index.js
+++ b/src/containers/editor/RepoEditor/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog, uid } from '@/utils'
+import { pluggedIn, buildLog, uid } from '@/utils'
 
 import GithubRepoPage from '@/components/GithubRepoPage'
 import SearchMan from './SearchMan'
@@ -81,4 +81,4 @@ const RepoEditorContainer = ({ repoEditor: store }) => {
   )
 }
 
-export default connectStore(RepoEditorContainer)
+export default pluggedIn(RepoEditorContainer)

--- a/src/containers/editor/RichEditor/index.js
+++ b/src/containers/editor/RichEditor/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import { useScript } from '@/hooks'
 
 import { useInit } from './logic'
@@ -32,4 +32,4 @@ const RichEditorContainer = ({ richEditor: store }) => {
   )
 }
 
-export default connectStore(RichEditorContainer)
+export default pluggedIn(RichEditorContainer)

--- a/src/containers/editor/VideoEditor/index.js
+++ b/src/containers/editor/VideoEditor/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Labeler from '@/containers/unit/Labeler'
 import FormItem from '@/components/FormItem'
@@ -131,4 +131,4 @@ const VideoEditorContainer = ({ videoEditor: store, attachment }) => {
   )
 }
 
-export default connectStore(VideoEditorContainer)
+export default pluggedIn(VideoEditorContainer)

--- a/src/containers/editor/WorksEditor/index.js
+++ b/src/containers/editor/WorksEditor/index.js
@@ -11,7 +11,7 @@ import T from 'prop-types'
 import { values } from 'ramda'
 
 import { METRIC } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Preview from './Preview'
 import Steps from './Steps'
@@ -50,4 +50,4 @@ WorksEditorContainer.defaultProps = {
   metric: METRIC.COMMUNITY,
 }
 
-export default connectStore(WorksEditorContainer)
+export default pluggedIn(WorksEditorContainer)

--- a/src/containers/layout/GlobalLayout/index.js
+++ b/src/containers/layout/GlobalLayout/index.js
@@ -11,7 +11,7 @@ import { values } from 'ramda'
 import { ANCHOR, METRIC } from '@/constant'
 import AnalysisService from '@/services/Analysis'
 import { useNetwork, useShortcut, usePlatform, useDevice } from '@/hooks'
-import { connectStore } from '@/utils'
+import { pluggedIn } from '@/utils'
 
 import ThemePalette from '@/containers/layout/ThemePalette'
 import Header from '@/containers/unit/Header'
@@ -136,4 +136,4 @@ GlobalLayoutContainer.defaultProps = {
   metric: METRIC.COMMUNITY,
 }
 
-export default connectStore(GlobalLayoutContainer)
+export default pluggedIn(GlobalLayoutContainer)

--- a/src/containers/layout/ThemePalette/index.js
+++ b/src/containers/layout/ThemePalette/index.js
@@ -10,7 +10,7 @@ import { ThemeProvider } from 'styled-components'
 import NextNprogress from 'nextjs-progressbar'
 
 import { ANCHOR } from '@/constant'
-import { connectStore } from '@/utils'
+import { pluggedIn } from '@/utils'
 import { usePlatform } from '@/hooks'
 
 // import MarkDownStyle from './MarkDownStyle'
@@ -46,7 +46,7 @@ const ThemeContainer = ({ children, theme: { themeData } }) => {
   )
 }
 
-export default connectStore(ThemeContainer)
+export default pluggedIn(ThemeContainer)
 
 // about meta theme-color
 // see: https://stackoverflow.com/questions/26960703/how-to-change-the-color-of-header-bar-and-address-bar-in-newest-chrome-version-o

--- a/src/containers/thread/CheatsheetThread/index.js
+++ b/src/containers/thread/CheatsheetThread/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { TYPE } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import EmptyThread from '@/components/EmptyThread'
 import { CheatSheetLoading } from '@/components/LoadingEffects'
@@ -80,4 +80,4 @@ const CheatsheetThreadContainer = ({ cheatsheetThread: store }) => {
   )
 }
 
-export default connectStore(CheatsheetThreadContainer)
+export default pluggedIn(CheatsheetThreadContainer)

--- a/src/containers/thread/JobsThread/index.js
+++ b/src/containers/thread/JobsThread/index.js
@@ -9,7 +9,7 @@ import { Waypoint } from 'react-waypoint'
 
 import { ICON_CMD } from '@/config'
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TagsBar from '@/containers/unit/TagsBar'
 
@@ -112,4 +112,4 @@ const JobsThreadContainer = ({ jobsThread: store }) => {
   )
 }
 
-export default connectStore(JobsThreadContainer)
+export default pluggedIn(JobsThreadContainer)

--- a/src/containers/thread/PostsThread/index.js
+++ b/src/containers/thread/PostsThread/index.js
@@ -9,7 +9,7 @@ import { Waypoint } from 'react-waypoint'
 import { contains } from 'ramda'
 
 import { C11N, THREAD, ROUTE } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TagsBar from '@/containers/unit/TagsBar'
 
@@ -171,4 +171,4 @@ const PostsThreadContainer = ({ postsThread: store }) => {
   )
 }
 
-export default connectStore(PostsThreadContainer)
+export default pluggedIn(PostsThreadContainer)

--- a/src/containers/thread/ReposThread/index.js
+++ b/src/containers/thread/ReposThread/index.js
@@ -9,7 +9,7 @@ import { Waypoint } from 'react-waypoint'
 
 import { ICON_CMD } from '@/config'
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TagsBar from '@/containers/unit/TagsBar'
 
@@ -107,4 +107,4 @@ const ReposThreadContainer = ({ reposThread: store }) => {
   )
 }
 
-export default connectStore(ReposThreadContainer)
+export default pluggedIn(ReposThreadContainer)

--- a/src/containers/thread/RoadmapThread/index.js
+++ b/src/containers/thread/RoadmapThread/index.js
@@ -8,7 +8,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TodoList from './TodoList'
 
@@ -29,4 +29,4 @@ const RoadmapThreadContainer = ({ roadmapThread: store }) => {
   )
 }
 
-export default connectStore(RoadmapThreadContainer)
+export default pluggedIn(RoadmapThreadContainer)

--- a/src/containers/thread/UsersThread/index.js
+++ b/src/containers/thread/UsersThread/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 import dynamic from 'next/dynamic'
 import { useTheme } from 'styled-components'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import { useScript } from '@/hooks'
 
 import NumDashboard from './NumDashboard'
@@ -63,4 +63,4 @@ const UsersThreadContainer = ({ usersThread }) => {
   )
 }
 
-export default connectStore(UsersThreadContainer)
+export default pluggedIn(UsersThreadContainer)

--- a/src/containers/thread/VideosThread/index.js
+++ b/src/containers/thread/VideosThread/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 
 import { ICON_CMD } from '@/config'
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TagsBar from '@/containers/unit/TagsBar'
 
@@ -105,4 +105,4 @@ const VideosThreadContainer = ({ videosThread }) => {
   )
 }
 
-export default connectStore(VideosThreadContainer)
+export default pluggedIn(VideosThreadContainer)

--- a/src/containers/thread/WikiThread/index.js
+++ b/src/containers/thread/WikiThread/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 
 import { ICON_CMD, COMMUNITY_WIKI } from '@/config'
 import { TYPE } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import EmptyThread from '@/components/EmptyThread'
 import { PublishButton } from '@/components/Buttons'
@@ -88,4 +88,4 @@ const WikiThreadContainer = ({ wikiThread }) => {
   )
 }
 
-export default connectStore(WikiThreadContainer)
+export default pluggedIn(WikiThreadContainer)

--- a/src/containers/tool/ArticleSticker/index.js
+++ b/src/containers/tool/ArticleSticker/index.js
@@ -9,7 +9,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Sticky from '@/components/Sticky'
 import GotoTop from '@/components/GotoTop'
@@ -74,4 +74,4 @@ ArticleStickerContainer.defaultProps = {
   testId: 'article-sticker',
 }
 
-export default connectStore(ArticleStickerContainer)
+export default pluggedIn(ArticleStickerContainer)

--- a/src/containers/tool/AvatarAdder/index.js
+++ b/src/containers/tool/AvatarAdder/index.js
@@ -8,7 +8,7 @@ import T from 'prop-types'
 
 import Tooltip from '@/components/Tooltip'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import AdderPanel from './AdderPanel'
 
 import { Wrapper, AddText } from './styles'
@@ -53,4 +53,4 @@ AvatarAdderContainer.defaultProps = {
   onConfirm: log,
 }
 
-export default connectStore(AvatarAdderContainer)
+export default pluggedIn(AvatarAdderContainer)

--- a/src/containers/tool/C11NSettingPanel/index.js
+++ b/src/containers/tool/C11NSettingPanel/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 
 import { ICON_CMD } from '@/config'
 import { VIEW } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { Tabs } from '@/components/Switcher'
 
@@ -78,4 +78,4 @@ const C11NSettingPanelContainer = ({ c11NSettingPanel: store }) => {
   )
 }
 
-export default connectStore(C11NSettingPanelContainer)
+export default pluggedIn(C11NSettingPanelContainer)

--- a/src/containers/tool/Cashier/index.js
+++ b/src/containers/tool/Cashier/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Modal from '@/components/Modal'
 import Sidebar from './Sidebar'
@@ -54,4 +54,4 @@ const CashierContainer = ({ cashier: store }) => {
   )
 }
 
-export default connectStore(CashierContainer)
+export default pluggedIn(CashierContainer)

--- a/src/containers/tool/CommunitySetter/index.js
+++ b/src/containers/tool/CommunitySetter/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Modal from '@/components/Modal'
 import { ArticleContentLoading } from '@/components/LoadingEffects'
@@ -49,4 +49,4 @@ const CommunitySetterContainer = ({ communitySetter: store }) => {
   )
 }
 
-export default connectStore(CommunitySetterContainer)
+export default pluggedIn(CommunitySetterContainer)

--- a/src/containers/tool/Doraemon/index.js
+++ b/src/containers/tool/Doraemon/index.js
@@ -7,7 +7,7 @@
 import React, { useEffect } from 'react'
 import usePortal from 'react-useportal'
 
-import { connectStore, buildLog, toggleGlobalBlur } from '@/utils'
+import { pluggedIn, buildLog, toggleGlobalBlur } from '@/utils'
 
 import InputEditor from './InputEditor'
 import ResultsList from './ResultsList'
@@ -80,4 +80,4 @@ const DoraemonContainer = ({ doraemon: store }) => {
   )
 }
 
-export default connectStore(DoraemonContainer)
+export default pluggedIn(DoraemonContainer)

--- a/src/containers/tool/Drawer/index.js
+++ b/src/containers/tool/Drawer/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import { useShortcut, useResize } from '@/hooks'
 
 import Viewer from './Viewer/index'
@@ -68,4 +68,4 @@ DrawerContainer.propTypes = {
 
 DrawerContainer.defaultProps = {}
 
-export default connectStore(DrawerContainer)
+export default pluggedIn(DrawerContainer)

--- a/src/containers/tool/ErrorBox/index.js
+++ b/src/containers/tool/ErrorBox/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Modal from '@/components/Modal'
 import { useShortcut } from '@/hooks'
@@ -67,4 +67,4 @@ const ErrorBoxContainer = ({ errorBox: store }) => {
   )
 }
 
-export default connectStore(ErrorBoxContainer)
+export default pluggedIn(ErrorBoxContainer)

--- a/src/containers/tool/FavoritesCats/index.js
+++ b/src/containers/tool/FavoritesCats/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 import T from 'prop-types'
 
 import { ICON_CMD } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Modal from '@/components/Modal'
 import SectionLabel from '@/components/SectionLabel'
@@ -101,4 +101,4 @@ FavoritesCatsContainer.defaultProps = {
   displayMode: 'hide',
 }
 
-export default connectStore(FavoritesCatsContainer)
+export default pluggedIn(FavoritesCatsContainer)

--- a/src/containers/tool/GirlVerifier/index.js
+++ b/src/containers/tool/GirlVerifier/index.js
@@ -10,7 +10,7 @@ import Input from '@/components/Input'
 import { Button } from '@/components/Buttons'
 
 import { ICON_CMD } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { Space } from '@/components/Common'
 import Modal from '@/components/Modal'
@@ -61,4 +61,4 @@ const GirlVerifierContainer = ({ girlVerifier: store }) => {
   )
 }
 
-export default connectStore(GirlVerifierContainer)
+export default pluggedIn(GirlVerifierContainer)

--- a/src/containers/tool/Informer/index.js
+++ b/src/containers/tool/Informer/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 import T from 'prop-types'
 
 import { ICON_CMD } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Modal from '@/components/Modal'
 import Header from './Header'
@@ -64,4 +64,4 @@ InformerContainer.defaultProps = {
   children: null,
 }
 
-export default connectStore(InformerContainer)
+export default pluggedIn(InformerContainer)

--- a/src/containers/tool/JoinModal/index.js
+++ b/src/containers/tool/JoinModal/index.js
@@ -9,7 +9,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Modal from '@/components/Modal'
 import FooterWechat from './FooterWechat'
@@ -41,4 +41,4 @@ JoinModalContainer.propTypes = {
 
 JoinModalContainer.defaultProps = {}
 
-export default connectStore(JoinModalContainer)
+export default pluggedIn(JoinModalContainer)

--- a/src/containers/tool/MailBox/index.js
+++ b/src/containers/tool/MailBox/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 import Tooltip from '@/components/Tooltip'
 
 import MailsPanel from './MailsPanel'
@@ -44,4 +44,4 @@ const MailBoxContainer = ({ mailBox: store }) => {
   )
 }
 
-export default connectStore(MailBoxContainer)
+export default pluggedIn(MailBoxContainer)

--- a/src/containers/unit/ArticleAuthorCard/index.js
+++ b/src/containers/unit/ArticleAuthorCard/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import UserInfo from './UserInfo'
 // import ReactionNumbers from './ReactionNumbers'
@@ -51,4 +51,4 @@ ArticleAuthorCardContainer.propTypes = {
 
 ArticleAuthorCardContainer.defaultProps = {}
 
-export default connectStore(ArticleAuthorCardContainer)
+export default pluggedIn(ArticleAuthorCardContainer)

--- a/src/containers/unit/ArticleBodyHeader/index.js
+++ b/src/containers/unit/ArticleBodyHeader/index.js
@@ -10,7 +10,7 @@ import { pluck } from 'ramda'
 
 import { ICON_CMD } from '@/config'
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Labeler from '@/containers/unit/Labeler'
 import CommunitySetter from '@/containers/tool/CommunitySetter'
@@ -122,4 +122,4 @@ ArticleBodyHeaderContainer.defaultProps = {
   middle: 'linker',
 }
 
-export default connectStore(ArticleBodyHeaderContainer)
+export default pluggedIn(ArticleBodyHeaderContainer)

--- a/src/containers/unit/ArticleFooter/index.js
+++ b/src/containers/unit/ArticleFooter/index.js
@@ -9,7 +9,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TagList from './TagList'
 import Actions from './Actions/index'
@@ -55,4 +55,4 @@ ArticleFooterContainer.defaultProps = {
   testId: 'article-footer',
 }
 
-export default connectStore(ArticleFooterContainer)
+export default pluggedIn(ArticleFooterContainer)

--- a/src/containers/unit/ArticleViewerHeader/index.js
+++ b/src/containers/unit/ArticleViewerHeader/index.js
@@ -8,7 +8,7 @@ import T from 'prop-types'
 import { values } from 'ramda'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import FavoritesCats from '@/containers/tool/FavoritesCats'
 import Maybe from '@/components/Maybe'
@@ -94,4 +94,4 @@ ArticleViewerHeaderContainer.defaultProps = {
   showLastSync: false,
 }
 
-export default connectStore(ArticleViewerHeaderContainer)
+export default pluggedIn(ArticleViewerHeaderContainer)

--- a/src/containers/unit/Comments/index.js
+++ b/src/containers/unit/Comments/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Modal from '@/components/Modal'
 import CommentEditor from './CommentEditor'
@@ -85,4 +85,4 @@ CommentsContainer.defaultProps = {
   locked: false,
 }
 
-export default connectStore(CommentsContainer)
+export default pluggedIn(CommentsContainer)

--- a/src/containers/unit/Footer/DesktopView/index.js
+++ b/src/containers/unit/Footer/DesktopView/index.js
@@ -9,7 +9,7 @@ import dynamic from 'next/dynamic'
 import { contains } from 'ramda'
 
 import { METRIC } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import JoinModal from '@/containers/tool/JoinModal'
 import Modal from '@/components/Modal'
@@ -93,4 +93,4 @@ const FooterContainer = ({ footer: store, metric }) => {
   )
 }
 
-export default connectStore(FooterContainer)
+export default pluggedIn(FooterContainer)

--- a/src/containers/unit/Header/DesktopView/ArticleEditorView.js
+++ b/src/containers/unit/Header/DesktopView/ArticleEditorView.js
@@ -10,7 +10,7 @@ import T from 'prop-types'
 
 import { ICON } from '@/config'
 import { METRIC } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Navigator from '@/components/Navigator'
 
@@ -84,4 +84,4 @@ HeaderContainer.propTypes = {
 
 HeaderContainer.defaultProps = {}
 
-export default connectStore(HeaderContainer)
+export default pluggedIn(HeaderContainer)

--- a/src/containers/unit/Header/DesktopView/ArticleView.js
+++ b/src/containers/unit/Header/DesktopView/ArticleView.js
@@ -9,7 +9,7 @@ import dynamic from 'next/dynamic'
 import T from 'prop-types'
 
 import { ICON } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import UserLister from '@/containers/user/UserLister'
 import Navigator from '@/components/Navigator'
@@ -90,4 +90,4 @@ HeaderContainer.propTypes = {
 
 HeaderContainer.defaultProps = {}
 
-export default connectStore(HeaderContainer)
+export default pluggedIn(HeaderContainer)

--- a/src/containers/unit/Header/DesktopView/CommunityVIew.js
+++ b/src/containers/unit/Header/DesktopView/CommunityVIew.js
@@ -10,7 +10,7 @@ import T from 'prop-types'
 import { values } from 'ramda'
 
 import { METRIC } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import UserLister from '@/containers/user/UserLister'
 import Navigator from '@/components/Navigator'
@@ -100,4 +100,4 @@ HeaderContainer.defaultProps = {
   metric: METRIC.COMMUNITY,
 }
 
-export default connectStore(HeaderContainer)
+export default pluggedIn(HeaderContainer)

--- a/src/containers/unit/Labeler/index.hooks.js
+++ b/src/containers/unit/Labeler/index.hooks.js
@@ -11,7 +11,7 @@ import { inject, observer } from 'mobx-react'
 import { findIndex, reject, propEq } from 'ramda'
 
 import { LABEL_POOL } from '@/config'
-import { connectStore, buildLog, storePlug, uid } from '@/utils'
+import { pluggedIn, buildLog, storePlug, uid } from '@/utils'
 
 import { withGuardian } from '@/hoc'
 import Maybe from '@/components/Maybe'
@@ -100,5 +100,5 @@ LabelerContainer.defaultProps = {
   onTagUnselect: log,
 }
 
-export default withGuardian(connectStore(LabelerContainer))
+export default withGuardian(pluggedIn(LabelerContainer))
 */

--- a/src/containers/unit/ModeLine/index.js
+++ b/src/containers/unit/ModeLine/index.js
@@ -13,7 +13,7 @@ import { values } from 'ramda'
 
 import { METRIC } from '@/constant'
 import { useDevice } from '@/hooks'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TopBar from './TopBar'
 
@@ -70,4 +70,4 @@ ModeLineContainer.defaultProps = {
   metric: METRIC.COMMUNITY,
 }
 
-export default connectStore(ModeLineContainer)
+export default pluggedIn(ModeLineContainer)

--- a/src/containers/unit/ModeLineMenu/index.js
+++ b/src/containers/unit/ModeLineMenu/index.js
@@ -11,7 +11,7 @@ import T from 'prop-types'
 import { values } from 'ramda'
 
 import { TYPE } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import GlobalMenu from './GlobalMenu/index'
 import SearchMenu from './SearchMenu'
@@ -61,4 +61,4 @@ ModeLineMenuContainer.defaultProps = {
   testId: 'mode-line-menu',
 }
 
-export default connectStore(ModeLineMenuContainer)
+export default pluggedIn(ModeLineMenuContainer)

--- a/src/containers/unit/Sidebar/RealSidebar.js
+++ b/src/containers/unit/Sidebar/RealSidebar.js
@@ -8,7 +8,7 @@ import React from 'react'
 import { filter, propEq } from 'ramda'
 
 import { ANCHOR } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Header from './Header'
 import MenuList from './MenuList/index'
@@ -64,4 +64,4 @@ const SidebarContainer = ({ sidebar: store }) => {
   )
 }
 
-export default connectStore(SidebarContainer)
+export default pluggedIn(SidebarContainer)

--- a/src/containers/unit/Sidebar/index.js
+++ b/src/containers/unit/Sidebar/index.js
@@ -7,7 +7,7 @@
 import React, { useRef, useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import LoadingBlocks from './LoadingBlocks'
 import PullButton from './PullButton'
@@ -49,4 +49,4 @@ const SidebarContainer = ({ sidebar: store }) => {
   )
 }
 
-export default connectStore(SidebarContainer)
+export default pluggedIn(SidebarContainer)

--- a/src/containers/unit/TagsBar/CardView.js
+++ b/src/containers/unit/TagsBar/CardView.js
@@ -9,7 +9,7 @@ import T from 'prop-types'
 
 import { ICON_CMD } from '@/config'
 import { THREAD, TOPIC } from '@/constant'
-import { buildLog, connectStore, sortByColor, Trans } from '@/utils'
+import { buildLog, pluggedIn, sortByColor, Trans } from '@/utils'
 
 import {
   Wrapper,
@@ -82,4 +82,4 @@ TagsBarContainer.defaultProps = {
   active: {},
 }
 
-export default connectStore(TagsBarContainer)
+export default pluggedIn(TagsBarContainer)

--- a/src/containers/unit/TagsBar/DesktopView.js
+++ b/src/containers/unit/TagsBar/DesktopView.js
@@ -9,7 +9,7 @@ import T from 'prop-types'
 
 import { ICON_CMD } from '@/config'
 import { THREAD, TOPIC } from '@/constant'
-import { buildLog, connectStore, sortByColor, Trans } from '@/utils'
+import { buildLog, pluggedIn, sortByColor, Trans } from '@/utils'
 
 import TagOptions from './TagOptions'
 
@@ -90,4 +90,4 @@ TagsBarContainer.defaultProps = {
   active: {},
 }
 
-export default connectStore(TagsBarContainer)
+export default pluggedIn(TagsBarContainer)

--- a/src/containers/user/UserBilling/index.js
+++ b/src/containers/user/UserBilling/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { ICON_CMD } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import SectionLabel from '@/components/SectionLabel'
 import UpgradeMenu from './UpgradeMenu'
@@ -45,4 +45,4 @@ const UserBillingContainer = ({ userBilling: store }) => {
   )
 }
 
-export default connectStore(UserBillingContainer)
+export default pluggedIn(UserBillingContainer)

--- a/src/containers/user/UserFavorited/index.js
+++ b/src/containers/user/UserFavorited/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import FavoritesCats from '@/containers/tool/FavoritesCats'
 import PagedContents from '@/components/PagedContents'
@@ -66,4 +66,4 @@ const UserFavoritedContainer = ({ userFavorited: store }) => {
   )
 }
 
-export default connectStore(UserFavoritedContainer)
+export default pluggedIn(UserFavoritedContainer)

--- a/src/containers/user/UserLister/index.js
+++ b/src/containers/user/UserLister/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { TYPE } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import EmptyLabel from '@/components/EmptyLabel'
 import Modal from '@/components/Modal'
@@ -78,4 +78,4 @@ const UserListerContainer = ({ userLister: store }) => {
   )
 }
 
-export default connectStore(UserListerContainer)
+export default pluggedIn(UserListerContainer)

--- a/src/containers/user/UserProfile/index.js
+++ b/src/containers/user/UserProfile/index.js
@@ -9,7 +9,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import NumbersPad from './NumbersPad'
 import ContributeMap from './ContributeMap'
@@ -50,4 +50,4 @@ UserProfileContainer.defaultProps = {
   testId: 'user-profile',
 }
 
-export default connectStore(UserProfileContainer)
+export default pluggedIn(UserProfileContainer)

--- a/src/containers/user/UserPublished/index.js
+++ b/src/containers/user/UserPublished/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import PagedContents from '@/components/PagedContents'
 import ThreadSelector from '@/components/ThreadSelector'
@@ -48,4 +48,4 @@ const UserPublishedContainer = ({ userPublished: store }) => {
   )
 }
 
-export default connectStore(UserPublishedContainer)
+export default pluggedIn(UserPublishedContainer)

--- a/src/containers/user/UserPublishedComments/index.js
+++ b/src/containers/user/UserPublishedComments/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ThreadSelector from '@/components/ThreadSelector'
 import CommentsToContent from './CommentsToContent'
@@ -42,4 +42,4 @@ const UserPublishedCommentsContainer = ({ userPublishedComments: store }) => {
   )
 }
 
-export default connectStore(UserPublishedCommentsContainer)
+export default pluggedIn(UserPublishedCommentsContainer)

--- a/src/containers/user/UserSettings/index.js
+++ b/src/containers/user/UserSettings/index.js
@@ -8,7 +8,7 @@ import React from 'react'
 
 import { ICON_CMD } from '@/config'
 import { C11N } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import { Br } from '@/components/Common'
 import { Radio } from '@/components/Switcher'
@@ -178,4 +178,4 @@ const UserSettingsContainer = ({ userSettings: store }) => {
   )
 }
 
-export default connectStore(UserSettingsContainer)
+export default pluggedIn(UserSettingsContainer)

--- a/src/containers/user/UserStared/index.js
+++ b/src/containers/user/UserStared/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import PagedContents from '@/components/PagedContents'
 import ThreadSelector from '@/components/ThreadSelector'
@@ -49,4 +49,4 @@ const UserStaredContainer = ({ userStared: store }) => {
   )
 }
 
-export default connectStore(UserStaredContainer)
+export default pluggedIn(UserStaredContainer)

--- a/src/containers/viewer/JobViewer/index.js
+++ b/src/containers/viewer/JobViewer/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Comments from '@/containers/unit/Comments'
 import ArticleViewerHeader from '@/containers/unit/ArticleViewerHeader'
@@ -72,4 +72,4 @@ const JobViewerContainer = ({ jobViewer: store, attachment }) => {
   )
 }
 
-export default connectStore(JobViewerContainer)
+export default pluggedIn(JobViewerContainer)

--- a/src/containers/viewer/MailsViewer/index.js
+++ b/src/containers/viewer/MailsViewer/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { ICON_CMD } from '@/config'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import TabSelector from '@/components/TabSelector'
 import MailLists from './MailLists'
@@ -61,4 +61,4 @@ const MailsViewerContainer = ({ mailsViewer: store }) => {
   )
 }
 
-export default connectStore(MailsViewerContainer)
+export default pluggedIn(MailsViewerContainer)

--- a/src/containers/viewer/PostViewer/index.js
+++ b/src/containers/viewer/PostViewer/index.js
@@ -9,7 +9,7 @@ import T from 'prop-types'
 import { pluck } from 'ramda'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import Comments from '@/containers/unit/Comments'
 import Labeler from '@/containers/unit/Labeler'
@@ -82,4 +82,4 @@ PostViewerContainer.defaultProps = {
   attachment: {},
 }
 
-export default connectStore(PostViewerContainer)
+export default pluggedIn(PostViewerContainer)

--- a/src/containers/viewer/RepoViewer/index.js
+++ b/src/containers/viewer/RepoViewer/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleViewerHeader from '@/containers/unit/ArticleViewerHeader'
 import ArticleBodyHeader from '@/containers/unit/ArticleBodyHeader'
@@ -57,4 +57,4 @@ const RepoViewerContainer = ({ repoViewer: store, attachment }) => {
   )
 }
 
-export default connectStore(RepoViewerContainer)
+export default pluggedIn(RepoViewerContainer)

--- a/src/containers/viewer/VideoViewer/index.js
+++ b/src/containers/viewer/VideoViewer/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 
 import { THREAD } from '@/constant'
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 import ArticleViewerHeader from '@/containers/unit/ArticleViewerHeader'
 import ArticleBodyHeader from '@/containers/unit/ArticleBodyHeader'
@@ -55,4 +55,4 @@ const VideoViewerContainer = ({ videoViewer: store, attachment }) => {
   )
 }
 
-export default connectStore(VideoViewerContainer)
+export default pluggedIn(VideoViewerContainer)

--- a/utils/index.js
+++ b/utils/index.js
@@ -76,7 +76,7 @@ export {
 } from './route'
 
 export {
-  connectStore,
+  pluggedIn,
   storePlug,
   markStates,
   flashState,

--- a/utils/mobx.js
+++ b/utils/mobx.js
@@ -38,7 +38,7 @@ export const storePlug = curry((selectedStore, props) => ({
 
 /*
  * inject sub-store to container
- * e.g: connectStore(HelloWorldContainer)
+ * e.g: pluggedIn(HelloWorldContainer)
    will make HelloWorldContainer connect to 'helloWorld' sub-store
  *
  * 将传入的 container 链接到相对应的子状态树
@@ -49,7 +49,7 @@ export const storePlug = curry((selectedStore, props) => ({
  * 注意： 容器组件的命名需遵守 XxxContainer 的约定规则 (以 Container 结尾)
  *
  */
-export const connectStore = (container, store) => {
+export const pluggedIn = (container, store) => {
   let subStoreName = ''
   // console.log('container displayName: ', container.displayName)
   if (store) {

--- a/utils/scripts/generators/container/class.js.hbs
+++ b/utils/scripts/generators/container/class.js.hbs
@@ -6,7 +6,7 @@
 
 import React from 'react'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 
 // import { } from './styles'
 import * as logic from './logic'
@@ -35,4 +35,4 @@ class {{ properCase name }}Container extends React.Component {
   }
 }
 
-export default connectStore({{ properCase name }}Container)
+export default pluggedIn({{ properCase name }}Container)

--- a/utils/scripts/generators/container/hooks.js.hbs
+++ b/utils/scripts/generators/container/hooks.js.hbs
@@ -9,7 +9,7 @@
 import React from 'react'
 import T from 'prop-types'
 
-import { connectStore, buildLog } from '@/utils'
+import { pluggedIn, buildLog } from '@/utils'
 {{#if wantI18n}}
 import { useTrans } from '@/hooks'
 {{/if}}
@@ -43,4 +43,4 @@ const {{ properCase name }}Container = ({{preCurly ""}} {{ camelCase name}}: sto
   testId: '{{ dashCase name}}',
 }
 
-export default connectStore({{ properCase name }}Container)
+export default pluggedIn({{ properCase name }}Container)


### PR DESCRIPTION
`connectStore` is a boring name, `pluggedIn` sounds vivid.
`plugin` is little ambiguous